### PR TITLE
Fix error in NFC NdefMEssageParser as reported in issue number 31

### DIFF
--- a/Smartphone/NFC/src/blackberry/nfc/ndef/NdefMessageParser.java
+++ b/Smartphone/NFC/src/blackberry/nfc/ndef/NdefMessageParser.java
@@ -255,7 +255,7 @@ public class NdefMessageParser implements Runnable {
                         urlBuffer.append("http://www.");
 
                     } else if(spPayloadBytes[0] == (byte) 0x02) {
-                        urlBuffer.append("https://");
+                        urlBuffer.append("https://www.");
 
                     } else if(spPayloadBytes[0] == (byte) 0x03) {
                         urlBuffer.append("http://");


### PR DESCRIPTION
This was raised as ( https://github.com/blackberry/WebWorks-Community-APIs/issues/31).

The URL coded abbreviation 0x02 in an NDEF Message should be interpreted as "https://www." instead of "https://." in line with the NFC Forum URI RTD specification.
