### PR TITLE
had wrong callback string in the js layer

### DIFF
--- a/BB10/VIBRATION/javascript_src/client.js
+++ b/BB10/VIBRATION/javascript_src/client.js
@@ -26,7 +26,7 @@ var _self = {},
 	_self.vibration_request = function (input, callback) {
 		
 		if ( typeof(callback) == "function" ) {
-			window.webworks.event.once(_ID, "requestVibrationCallbackResult", callback);
+			window.webworks.event.once(_ID, "vibration_requestCallbackResult", callback);
 		} 
 
 		window.webworks.execAsync(_ID, "vibration_request", { input: input});


### PR DESCRIPTION
the callback event string in the javascript layer was :
requestVibrationCallbackResult

but it required this string to match from C++
vibration_requestCallbackResult

hidaya helped me find that out. I think I had made the change locally at some point so thats why the test app had worked for me. This change should resolve the issue and all a callback function to fired when the vibration function returns.
