### PR TITLE
fixes breaking search for UiWebView.

### DIFF
--- a/BB10/PreventSleep/ext/community.preventsleep/index.js
+++ b/BB10/PreventSleep/ext/community.preventsleep/index.js
@@ -31,8 +31,10 @@ module.exports = {
 		// look for the UIWebView in the set of WebViews.
 		var views = qnx.webplatform.getWebViews();
 		var handle = null;
+		var z = -1;
 		for (var i = 0; i < views.length; i++) {
-			if (views[i].constructor.name == "UIWebView"){
+			if (views[i].zOrder > z){
+				z = views[i].zOrder;
 				handle = views[i].jsScreenWindowHandle;
 			}
 		}


### PR DESCRIPTION
Fix for #187

The class name for the WebViews is no longer different in 10.2. This uses the zOrder (and would have been a better choice originally anyway).
