### PR TITLE
Always use webkitRequestFileSystem to prevent collisions with the Apache File Plugin.

### DIFF
--- a/BB10-Cordova/BarcodeScanner/plugin/www/client.js
+++ b/BB10-Cordova/BarcodeScanner/plugin/www/client.js
@@ -103,9 +103,7 @@
 	};
 
 	function readFile(filename) {
-		window.requestFileSystem  = window.requestFileSystem || window.webkitRequestFileSystem;
-
-		window.requestFileSystem(
+		window.webkitRequestFileSystem(
 			window.TEMPORARY, 
 			fsSize, 
 			function (fs) {

--- a/BB10/BarcodeScanner/ext/community.barcodescanner/client.js
+++ b/BB10/BarcodeScanner/ext/community.barcodescanner/client.js
@@ -82,9 +82,7 @@ var _self = {},
 	var sleepPrevented = false;
 
 	function readFile(filename) {
-		window.requestFileSystem  = window.requestFileSystem || window.webkitRequestFileSystem;
-
-		window.requestFileSystem(window.TEMPORARY, fsSize,
+		window.webkitRequestFileSystem(window.TEMPORARY, fsSize,
 			function (fs) {
 				fs.root.getFile(filename, {create: false},
 					function (fileEntry) {


### PR DESCRIPTION
As pointed out in Issue #320, if people are using the Apache File Plugin, the `readFile` function throws calls the `errorHandler` with `error.code = 1`. This is because the Apache File Plugin overwrites `requestFileSystem`.

Since there's no reason to use `requestFileSystem` over `webkitRequestFileSystem` on BB10, this pull request removes the dependancy of `requestFileSystem` in favour of always using `webkitRequestFileSystem`.
