### PR TITLE
Modifying to use Cordova instead of deprecated WebWorks command

### DIFF
--- a/BB10-Cordova/NowPlaying/nowplaying_build.sh
+++ b/BB10-Cordova/NowPlaying/nowplaying_build.sh
@@ -5,4 +5,5 @@ cd debug1
 cordova plugin add ../plugin
 rm -rf www/
 cp -r ../sample/* ./
+cordova platform add blackberry10
 cordova run

--- a/BB10-Cordova/NowPlaying/nowplaying_build.sh
+++ b/BB10-Cordova/NowPlaying/nowplaying_build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 rm -rf debug1
-webworks create debug1
+cordova create debug1
 cd debug1
-webworks plugin add ../plugin
+cordova plugin add ../plugin
 rm -rf www/
 cp -r ../sample/* ./
-webworks run
+cordova run


### PR DESCRIPTION
Modifying to use 'Cordova' instead of deprecated 'WebWorks' command in the script that uses the local nowPlaying plugin to create a new sample application (off of the application in /sample).